### PR TITLE
Enable security.checkOrigin for CSRF protection

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -15,4 +15,7 @@ export default defineConfig({
         page !== 'https://arnaudhervy.com/samples/user-guide/'
     }),
   ],
+  security: {
+    checkOrigin: true
+  },
 });


### PR DESCRIPTION
This pull request enables `security.checkOrigin` to provide Cross-Site Request Forgery (CSRF) protection.