### PR TITLE
Switch to static output and fix CSS issues

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,7 +5,7 @@ import netlify from "@astrojs/netlify";
 
 // https://astro.build/config
 export default defineConfig({
-  output: 'server',
+  output: 'static',
   adapter: netlify(),
   site: 'https://arnaudhervy.com',
   integrations: [

--- a/src/components/MainHead.astro
+++ b/src/components/MainHead.astro
@@ -32,7 +32,7 @@ const {
 	href="/fonts/Mona-Sans.woff2"
 	as="font"
 	type="font/woff2"
-	crossorigin
+	crossorigin="anonymous"
 />
 <link rel="canonical" href={Astro.url.href} />
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -156,13 +156,18 @@ import profilePicture from '../assets/profile-picture.jpg';
 		}
 
 		.section {
-			grid-template-columns: repeat(4, 1fr);
-			grid-template-areas: 'header header header header' 'gallery gallery gallery gallery'
-			gap: 5rem;
+  			display: grid;
+  			grid-template-columns: repeat(4, 1fr);
+  			grid-template-areas:
+    			"header header header header"
+    			"gallery gallery gallery gallery";
+  			gap: 5rem;
 		}
 
 		.section.with-cta {
-			grid-template-areas: 'header header header cta' 'gallery gallery gallery gallery'
+  			grid-template-areas:
+    			"header header header cta"
+    			"gallery gallery gallery gallery";
 		}
 
 		.section-header {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -117,13 +117,52 @@
 
 @font-face {
 	font-family: 'Mona Sans';
-	src:
-	  url('/fonts/Mona-Sans.woff2') format('woff2 supports variations'),
-	  url('/fonts/Mona-Sans.woff2') format('woff2-variations');
-	font-weight: 200 300 400 500 600 700 900;
-	font-stretch: 75% 125%;
+	src: url('/fonts/Mona-Sans.woff2') format('woff2');
+	font-weight: 200;
 	font-display: swap;
-  }
+}
+@font-face {
+	font-family: 'Mona Sans';
+	src: url('/fonts/Mona-Sans.woff2') format('woff2');
+	font-weight: 300;
+	font-display: swap;
+}
+@font-face {
+	font-family: 'Mona Sans';
+	src: url('/fonts/Mona-Sans.woff2') format('woff2');
+	font-weight: 400;
+	font-display: swap;
+}
+@font-face {
+	font-family: 'Mona Sans';
+	src: url('/fonts/Mona-Sans.woff2') format('woff2');
+	font-weight: 500;
+	font-display: swap;
+}
+@font-face {
+	font-family: 'Mona Sans';
+	src: url('/fonts/Mona-Sans.woff2') format('woff2');
+	font-weight: 600;
+	font-display: swap;
+}
+@font-face {
+	font-family: 'Mona Sans';
+	src: url('/fonts/Mona-Sans.woff2') format('woff2');
+	font-weight: 700;
+	font-display: swap;
+}
+@font-face {
+	font-family: 'Mona Sans';
+	src: url('/fonts/Mona-Sans.woff2') format('woff2');
+	font-weight: 800;
+	font-display: swap;
+}
+@font-face {
+	font-family: 'Mona Sans';
+	src: url('/fonts/Mona-Sans.woff2') format('woff2');
+	font-weight: 900;
+	font-display: swap;
+}
 
 html,
 body {


### PR DESCRIPTION
This pull request:

- updates the Astro configuration to use static output instead of server output.
- addresses CSS issues related to font loading (ensuring fonts load without warnings).
- fixes syntax errors in the `grid-template-areas` property to improve layout consistency.