### PR TITLE
Improve skip link accessibility and Safari compatibility

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -20,7 +20,7 @@ const { title, description } = Astro.props;
 		<MainHead title={title} description={description} />
 	</head>
 	<body>
-		<a href="#main-content" class="sr-only sr-only-focusable">Skip to main content</a>
+		<a href="#main-content" class="sr-only sr-only-focusable" tabindex="0">Skip to main content</a>
 		<div>
 			<Nav />
 			<slot />


### PR DESCRIPTION
This pull request includes a small accessibility improvement to the `src/layouts/BaseLayout.astro` file by adding a `tabindex="0"` attribute to the "Skip to main content" link, ensuring it is keyboard-navigable.