### PR TITLE
Remove unused imports of the Icon component

### DIFF
--- a/src/components/ContactCTA.astro
+++ b/src/components/ContactCTA.astro
@@ -1,6 +1,5 @@
 ---
 import CallToAction from "./CallToAction.astro";
-import Icon from "./Icon.astro";
 ---
 
 <aside aria-labelledby="contact-heading">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,7 +4,6 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 import CallToAction from "../components/CallToAction.astro";
 import Grid from "../components/Grid.astro";
 import Hero from "../components/Hero.astro";
-import Icon from "../components/Icon.astro";
 import PortfolioPreview from "../components/PortfolioPreview.astro";
 import ContactCTA from "../components/ContactCTA.astro";
 import Skills from "../components/Skills.astro";


### PR DESCRIPTION
This pull request removes unused imports of the `Icon.astro` component from two files to clean up the codebase. No functional changes are introduced.