### PR TITLE
Add preload for critical profile image

### DIFF
--- a/src/components/MainHead.astro
+++ b/src/components/MainHead.astro
@@ -22,6 +22,9 @@ const origin = Astro.url?.origin ?? 'https://arnaudhervy.com';
 <meta name="keywords" content="technical writer, UX writer, API documentation, user guides, software documentation, Arnaud Hervy, Nantes, France" />
 <title>{title}</title>
 
+<!-- Preload critical assets -->
+<link rel="preload" href="/assets/profile-picture.jpg" as="image" type="image/jpeg" fetchpriority="high" />
+
 <link rel="canonical" href={url} />
 <link rel="sitemap" href="/sitemap-index.xml" />
 <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />


### PR DESCRIPTION
This pull request makes a small improvement to the `src/components/MainHead.astro` file by preloading a critical image asset to optimize page load performance.