### PR TITLE
chore: group @typescript-eslint/* packages in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      typescript-eslint:
+        patterns:
+          - "@typescript-eslint/*"
     commit-message:
       prefix: "npm"
     rebase-strategy: "auto"


### PR DESCRIPTION
This pull request introduces a new configuration in `.github/dependabot.yml` to better manage dependency updates. The main change is the addition of a group for all `@typescript-eslint/*` packages, which will allow Dependabot to update these related dependencies together in a single pull request.