### PR TITLE
chore(perf): remove global preload for profile picture

### DIFF
--- a/src/components/MainHead.astro
+++ b/src/components/MainHead.astro
@@ -25,15 +25,6 @@ const origin = Astro.url?.origin ?? 'https://arnaudhervy.com';
 />
 <title>{title}</title>
 
-<!-- Preload critical assets -->
-<link
-	rel="preload"
-	href="/assets/profile-picture.jpg"
-	as="image"
-	type="image/jpeg"
-	fetchpriority="high"
-/>
-
 <link rel="canonical" href={url} />
 <link rel="sitemap" href="/sitemap-index.xml" />
 <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -24,6 +24,8 @@ import profilePicture from '../assets/profile-picture.jpg';
 					formats={['avif', 'webp']}
 					alt="Profile picture of Arnaud Hervy, technical writer"
 					class="profile-img"
+					loading="eager"
+					fetchpriority="high"
 				/>
 			</header>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -35,6 +35,7 @@ const projects = (await getCollection('portfolio')).sort((a, b) => {
 					alt="Profile picture of Arnaud Hervy, technical writer"
 					class="profile-img"
 					loading="eager"
+					fetchpriority="high"
 				/>
 			</header>
 			<Skills />


### PR DESCRIPTION
This pull request focuses on optimizing image loading performance and simplifying the handling of critical assets. The main change is the removal of the explicit preload link for the profile picture in the HTML head, replaced by setting image loading priorities directly on the `<img>` tags. This ensures that the profile picture still loads quickly without relying on preloading via the head, resulting in a cleaner and more maintainable approach.