### PR TITLE
feat: Simplify accessible color palette

### DIFF
--- a/src/pages/samples/how-to.html
+++ b/src/pages/samples/how-to.html
@@ -1,126 +1,151 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en-US">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<meta
+			name="description"
+			content="Sample how-to guide by Arnaud Hervy demonstrating how to manage API keys in a software platform."
+		/>
+		<meta
+			name="keywords"
+			content="technical writing, how-to guide, sample, API keys, instructions, software, documentation"
+		/>
 
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description"
-        content="Sample how-to guide by Arnaud Hervy demonstrating how to manage API keys in a software platform.">
-    <meta name="keywords"
-        content="technical writing, how-to guide, sample, API keys, instructions, software, documentation">
+		<link rel="canonical" href="https://arnaudhervy.com/samples/how-to/" />
 
-    <link rel="canonical" href="https://arnaudhervy.com/samples/how-to/" />
+		<meta name="author" content="Arnaud Hervy" />
 
-    <meta name="author" content="Arnaud Hervy" />
+		<meta property="og:title" content="Sample how-to guide by Arnaud Hervy: Manage API keys" />
+		<meta
+			property="og:description"
+			content="Learn how to create and revoke API keys with clear instructions in this sample how-to guide by Arnaud Hervy."
+		/>
+		<meta property="og:image" content="https://arnaudhervy.com/assets/how-to.png" />
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://arnaudhervy.com/samples/how-to/" />
+		<meta name="twitter:card" content="summary_large_image" />
 
-    <meta property="og:title" content="Sample how-to guide by Arnaud Hervy: Manage API keys">
-    <meta property="og:description"
-        content="Learn how to create and revoke API keys with clear instructions in this sample how-to guide by Arnaud Hervy.">
-    <meta property="og:image" content="https://arnaudhervy.com/assets/how-to.png">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://arnaudhervy.com/samples/how-to/">
-    <meta name="twitter:card" content="summary_large_image">
+		<title>Sample how-to guide: Manage API Keys</title>
 
-    <title>Sample how-to guide: Manage API Keys</title>
+		<style>
+			body {
+				font-family:
+					system-ui,
+					-apple-system,
+					BlinkMacSystemFont,
+					'Segoe UI',
+					Roboto,
+					Oxygen,
+					Ubuntu,
+					Cantarell,
+					'Open Sans',
+					'Helvetica Neue',
+					sans-serif;
+				margin: 20px;
+				background-color: #f8fafc;
+				color: #475569;
+			}
 
-    <style>
-        body {
-            font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-            margin: 20px;
-            background-color: #f4f4f4;
-            color: #333;
-        }
+			main {
+				background-color: #ffffff;
+				padding: 20px;
+				border-radius: 8px;
+				border: 1px solid #cbd5e1;
+				box-shadow: 0 1px 2px rgba(17, 24, 39, 0.08);
+				max-width: 800px;
+				margin: 0 auto;
+				margin-bottom: 20px;
+			}
 
-        main {
-            background-color: #fff;
-            padding: 20px;
-            border-radius: 8px;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-            max-width: 800px;
-            margin: 0 auto;
-            margin-bottom: 20px;
-        }
+			h1,
+			h2 {
+				color: #1d4ed8;
+				margin-top: 20px;
+			}
 
-        h1,
-        h2 {
-            color: #007BFF;
-            margin-top: 20px;
-        }
+			ul,
+			ol {
+				margin-bottom: 10px;
+			}
 
-        ul,
-        ol {
-            margin-bottom: 10px;
-        }
+			li {
+				margin-bottom: 5px;
+			}
 
-        li {
-            margin-bottom: 5px;
-        }
+			.alert {
+				padding: 10px;
+				margin-bottom: 15px;
+				border-radius: 5px;
+			}
 
-        .alert {
-            padding: 10px;
-            margin-bottom: 15px;
-            border-radius: 5px;
-        }
+			.important {
+				border: 1px solid #1d4ed8;
+				font-weight: bold;
+			}
 
-        .important {
-            border: 1px solid #FFA500;
-            font-weight: bold;
-        }
+			.warning {
+				border: 1px solid #b91c1c;
+				font-weight: bold;
+			}
+		</style>
+	</head>
 
-        .warning {
-            border: 1px solid #FF0000;
-            font-weight: bold;
-        }
-    </style>
-</head>
+	<body>
+		<header>
+			<nav>
+				<a href="https://arnaudhervy.com">Back to arnaudhervy.com</a>
+			</nav>
+		</header>
 
-<body>
+		<main id="main-content">
+			<h1>Manage API Keys</h1>
 
-    <header>
-        <nav>
-            <a href="https://arnaudhervy.com">Back to arnaudhervy.com</a>
-        </nav>
-    </header>
+			<p>
+				The Llama API authenticates requests using API Keys. These API keys represent the required
+				credentials to use the Llama API.
+			</p>
+			<p>Only Platform Administrators and Platform Owners can manage API keys.</p>
 
-    <main id="main-content">
+			<h2 id="create-api-key">Create an API Key</h2>
 
-        <h1>Manage API Keys</h1>
+			<p>
+				From your Admin account, you can create up to 10 API keys that carry the same access rights
+				for use with the platform.
+			</p>
+			<ol>
+				<li>Go to your <strong>Admin</strong> account.</li>
+				<li>In the <strong>Platform settings</strong> section, click <strong>API</strong>.</li>
+				<li>Click <strong>Add API key</strong>.</li>
+				<li>
+					When asked, enter a meaningful label for the API key. For example, indicate which
+					integration uses this API key.
+				</li>
+				<li>Click <strong>Create</strong>.</li>
+				<li>
+					Copy your API key somewhere safe.<br />
+					<p class="alert important">
+						You can only view the API key once. If you lose this API key, you need to create a new
+						one.
+					</p>
+				</li>
+				<li>Click <strong>Close</strong>.</li>
+			</ol>
 
-        <p>The Llama API authenticates requests using API Keys. These API keys represent the required credentials to use
-            the Llama API.</p>
-        <p>Only Platform Administrators and Platform Owners can manage API keys.</p>
-
-        <h2 id="create-api-key">Create an API Key</h2>
-
-        <p>From your Admin account, you can create up to 10 API keys that carry the same access rights for use with the
-            platform.</p>
-        <ol>
-            <li>Go to your <strong>Admin</strong> account.</li>
-            <li>In the <strong>Platform settings</strong> section, click <strong>API</strong>.</li>
-            <li>Click <strong>Add API key</strong>.</li>
-            <li>When asked, enter a meaningful label for the API key. For example, indicate which integration uses this
-                API key.</li>
-            <li>Click <strong>Create</strong>.</li>
-            <li>Copy your API key somewhere safe.<br />
-                <p class="alert important">You can only view the API key once.
-                    If you lose this API key, you need to create a new one.</p>
-            </li>
-            <li>Click <strong>Close</strong>.</li>
-        </ol>
-
-        <h2 id="revoke-api-key">Revoke an API key</h2>
-        <p>If you no longer use an API or think an API key has been compromised, you can revoke it.</p>
-        <p class="alert warning">Once an API key is revoked, it is permanently deleted. Any associated integration stops
-            working.</p>
-        <ol>
-            <li>Go to your <strong>Admin</strong> account.</li>
-            <li>In the <strong>Platform settings</strong> section, click <strong>API</strong>.</li>
-            <li>Find the API key you want to revoke, then click <strong>Revoke</strong>.</li>
-            <li>When asked, click <strong>Yes, revoke</strong>.</li>
-        </ol>
-
-    </main>
-
-</body>
-
+			<h2 id="revoke-api-key">Revoke an API key</h2>
+			<p>
+				If you no longer use an API or think an API key has been compromised, you can revoke it.
+			</p>
+			<p class="alert warning">
+				Once an API key is revoked, it is permanently deleted. Any associated integration stops
+				working.
+			</p>
+			<ol>
+				<li>Go to your <strong>Admin</strong> account.</li>
+				<li>In the <strong>Platform settings</strong> section, click <strong>API</strong>.</li>
+				<li>Find the API key you want to revoke, then click <strong>Revoke</strong>.</li>
+				<li>When asked, click <strong>Yes, revoke</strong>.</li>
+			</ol>
+		</main>
+	</body>
 </html>

--- a/src/pages/samples/user-guide.html
+++ b/src/pages/samples/user-guide.html
@@ -1,132 +1,166 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<meta
+			name="description"
+			content="Sample user guide By Arnaud Hervy demonstrating clear instructions and visuals for a new navigation launch."
+		/>
+		<meta
+			name="keywords"
+			content="technical writing, user guide, sample, navigation, instructions, software, documentation"
+		/>
 
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description"
-        content="Sample user guide By Arnaud Hervy demonstrating clear instructions and visuals for a new navigation launch.">
-    <meta name="keywords"
-        content="technical writing, user guide, sample, navigation, instructions, software, documentation">
+		<link rel="canonical" href="https://arnaudhervy.com/samples/user-guide/" />
 
-    <link rel="canonical" href="https://arnaudhervy.com/samples/user-guide/" />
+		<meta name="author" content="Arnaud Hervy" />
 
-    <meta name="author" content="Arnaud Hervy" />
+		<meta
+			property="og:title"
+			content="Sample user guide by Arnaud Hervy: New navigation launch in Q4 2023"
+		/>
+		<meta
+			property="og:description"
+			content="See how Arnaud Hervy can make complex changes easy to understand with this sample user guide."
+		/>
+		<meta property="og:image" content="https://arnaudhervy.com/assets/user-guide.png" />
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://arnaudhervy.com/samples/user-guide/" />
+		<meta name="twitter:card" content="summary_large_image" />
 
-    <meta property="og:title" content="Sample user guide by Arnaud Hervy: New navigation launch in Q4 2023">
-    <meta property="og:description"
-        content="See how Arnaud Hervy can make complex changes easy to understand with this sample user guide.">
-    <meta property="og:image" content="https://arnaudhervy.com/assets/user-guide.png">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://arnaudhervy.com/samples/user-guide/">
-    <meta name="twitter:card" content="summary_large_image">
+		<title>Sample user guide: New navigation launch in Q4 2023</title>
 
-    <title>Sample user guide: New navigation launch in Q4 2023</title>
+		<style>
+			body {
+				font-family:
+					system-ui,
+					-apple-system,
+					BlinkMacSystemFont,
+					'Segoe UI',
+					Roboto,
+					Oxygen,
+					Ubuntu,
+					Cantarell,
+					'Open Sans',
+					'Helvetica Neue',
+					sans-serif;
+				margin: 20px;
+				background-color: #f8fafc;
+				color: #475569;
+			}
 
-    <style>
-        body {
-            font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-            margin: 20px;
-            background-color: #f4f4f4;
-            color: #333;
-        }
+			main {
+				background-color: #ffffff;
+				padding: 20px;
+				border-radius: 8px;
+				border: 1px solid #cbd5e1;
+				box-shadow: 0 1px 2px rgba(17, 24, 39, 0.08);
+				max-width: 800px;
+				margin: 0 auto;
+				margin-bottom: 20px;
+			}
 
-        main {
-            background-color: #fff;
-            padding: 20px;
-            border-radius: 8px;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-            max-width: 800px;
-            margin: 0 auto;
-            margin-bottom: 20px;
-        }
+			h1,
+			h2,
+			h3 {
+				color: #1d4ed8;
+				margin-top: 20px;
+			}
 
-        h1,
-        h2,
-        h3 {
-            color: #007BFF;
-            margin-top: 20px;
-        }
+			ul,
+			ol {
+				margin-bottom: 10px;
+			}
 
-        ul,
-        ol {
-            margin-bottom: 10px;
-        }
+			li {
+				margin-bottom: 5px;
+			}
 
-        li {
-            margin-bottom: 5px;
-        }
+			img {
+				height: 100%;
+				width: 100%;
+			}
+		</style>
+	</head>
 
-        img {
-            height: 100%;
-            width: 100%;
-        }
-    </style>
-</head>
+	<body>
+		<header>
+			<nav>
+				<a href="https://arnaudhervy.com">Back to arnaudhervy.com</a>
+			</nav>
+		</header>
 
-<body>
+		<main id="main-content">
+			<h1>The new navigation launches in Q4 2023. You will find what you need more easily.</h1>
 
-    <header>
-        <nav>
-            <a href="https://arnaudhervy.com">Back to arnaudhervy.com</a>
-        </nav>
-    </header>
+			<p>
+				Here's a quick overview of what's new and how the new navigation will make finding what you
+				need easier, starting in Q4 2023.
+			</p>
 
-    <main id="main-content">
+			<h2 id="new-nav-overview">Overview of the new navigation</h2>
 
-        <h1>The new navigation launches in Q4 2023. You will find what you need more easily.</h1>
+			<img
+				src="/assets/new-nav-overview.png"
+				alt="Overview of the new navigation"
+				aria-label="Overview of the new navigation"
+			/>
 
-        <p>Here's a quick overview of what's new and how the new navigation will make finding what you need easier,
-            starting in Q4 2023.</p>
+			<h3 id="new-top-nav">New top navigation menu</h3>
+			<p>
+				Quickly find what you need with the top navigation menu on all pages (1), excluding the
+				course player and editors. Breadcrumbs make it easier to navigate through pages and know
+				where you are.
+			</p>
+			<h3 id="quicker-page-access">Quicker page access</h3>
+			<p>Directly jump to any page in one click (2). No more clicking through menus!</p>
+			<h3 id="quicker-dashboard-access">Quicker dashboard access</h3>
+			<p>
+				Use filters (2) to view course info, user stats, and more. Switch from the Content to the
+				Stats view (3) to access dashboards directly from the homepage and group pages.
+			</p>
+			<h3 id="workspaces">Organized workspaces</h3>
 
-        <h2 id="new-nav-overview">Overview of the new navigation</h2>
+			<p>Keep things organized with two workspaces (4):</p>
+			<ul>
+				<li>From the home workspace, you will access objects related to all groups.</li>
+				<li>From the group workspace, you will access objects related to the selected group.</li>
+			</ul>
 
-        <img src="/assets/new-nav-overview.png" alt="Overview of the new navigation"
-            aria-label="Overview of the new navigation">
+			<h2>View user stats quickly</h2>
+			<p>
+				On the homepage or any group page, select the <strong>Users</strong> filter to view user
+				stats.
+			</p>
+			<img
+				src="/assets/new-nav-user-stats.gif"
+				alt="User stats filter demonstration"
+				aria-label="User stats filter demonstration"
+			/>
+			<h2>Access dashboard data directly from the homepage</h2>
+			<p>Admins, coaches, authors, and owners can now:</p>
+			<ul>
+				<li>view any course, user, program session, and more directly from the homepage,</li>
+				<li>and switch to the "Stats" view to view quick insights.</li>
+			</ul>
+			<p>
+				<img
+					src="/assets/new-nav-chips.gif"
+					alt="Dashboard data access demonstration"
+					aria-label="Dashboard data access demonstration"
+				/>
+			</p>
+			<p>For learners, the homepage and group pages won't change.</p>
 
-        <h3 id="new-top-nav">New top navigation menu</h3>
-        <p>Quickly find what you need with the top navigation menu on all pages (1), excluding the course player and
-            editors.
-            Breadcrumbs make it easier to navigate through pages and know where you are.</p>
-        <h3 id="quicker-page-access">Quicker page access</h3>
-        <p>Directly jump to any page in one click (2). No more clicking through menus!</p>
-        <h3 id="quicker-dashboard-access">Quicker dashboard access</h3>
-        <p>Use filters (2) to view course info, user stats, and more. Switch from the Content to the Stats view (3) to
-            access dashboards directly from the homepage and group pages.</p>
-        <h3 id="workspaces">Organized workspaces</h3>
-
-        <p>Keep things organized with two workspaces (4):</p>
-        <ul>
-            <li>From the home workspace, you will access objects related to all groups.</li>
-            <li>From the group workspace, you will access objects related to the selected group.</li>
-        </ul>
-
-        <h2>View user stats quickly</h2>
-        <p>On the homepage or any group page, select the <strong>Users</strong> filter to view user stats.</p>
-        <img src="/assets/new-nav-user-stats.gif" alt="User stats filter demonstration"
-            aria-label="User stats filter demonstration">
-        <h2>Access dashboard data directly from the homepage</h2>
-        <p>Admins, coaches, authors, and owners can now:</p>
-        <ul>
-            <li>view any course, user, program session, and more directly from the homepage,</li>
-            <li>and switch to the "Stats" view to view quick insights.</li>
-        </ul>
-        <p><img src="/assets/new-nav-chips.gif" alt="Dashboard data access demonstration"
-                aria-label="Dashboard data access demonstration">
-        </p>
-        <p>For learners, the homepage and group pages won't change.</p>
-
-        <h2>Access reports from the Stats view</h2>
-        <p>With the new navigation experience, access to reports will move:</p>
-        <ol>
-            <li>On the homepage, select the <strong>All</strong> filter.</li>
-            <li>Switch to the <strong>Stats</strong> view.</li>
-            <li>Open the <strong>Custom Reports</strong> tab.</li>
-        </ol>
-        <p>From this page, you will be able to create reports and view saved reports.</p>
-
-    </main>
-
-</body>
-
+			<h2>Access reports from the Stats view</h2>
+			<p>With the new navigation experience, access to reports will move:</p>
+			<ol>
+				<li>On the homepage, select the <strong>All</strong> filter.</li>
+				<li>Switch to the <strong>Stats</strong> view.</li>
+				<li>Open the <strong>Custom Reports</strong> tab.</li>
+			</ol>
+			<p>From this page, you will be able to create reports and view saved reports.</p>
+		</main>
+	</body>
 </html>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,39 +4,52 @@
 /* === 1. CSS VARIABLES =================================================== */
 /* ======================================================================== */
 :root {
-	/* Grayscale (light theme) */
-	--gray-0: #0a0c10;
-	--gray-50: #121720;
-	--gray-100: #1f2937;
+	/* Accessible light palette */
+	--color-text: #111827;
+	--color-heading: #1f2937;
+	--color-muted: #475569;
+	--color-border: #cbd5e1;
+	--color-border-strong: #94a3b8;
+	--color-surface: #ffffff;
+	--color-surface-muted: #eef2f6;
+	--color-background: #f8fafc;
+	--color-accent: #1d4ed8;
+	--color-accent-hover: #1e3a8a;
+	--color-accent-soft: #eff6ff;
+	--color-success: #047857;
+	--color-danger: #b91c1c;
+
+	/* Compatibility aliases */
+	--gray-0: var(--color-text);
+	--gray-50: var(--color-text);
+	--gray-100: var(--color-heading);
 	--gray-200: #334155;
-	--gray-300: #475569;
+	--gray-300: var(--color-muted);
 	--gray-400: #64748b;
-	--gray-500: #94a3b8;
-	--gray-600: #cbd5e1;
-	--gray-700: #e2e8f0;
-	--gray-800: #f1f5f9;
-	--gray-900: #f8fafc;
-	--gray-999: #ffffff;
+	--gray-500: var(--color-border-strong);
+	--gray-600: var(--color-border);
+	--gray-700: #d7dde5;
+	--gray-800: var(--color-surface-muted);
+	--gray-900: var(--color-background);
+	--gray-999: var(--color-surface);
 
 	--gray-999-basis: 0, 0%, 100%;
-	--gray-999_40: hsla(var(--gray-999-basis), 0.4);
+	--gray-999_40: rgba(255, 255, 255, 0.4);
 
-	/* Accent colors */
-	--accent-regular: #4f46e5;
-	--accent-regular-rgb: 79, 70, 229;
-	--accent-light: #818cf8;
-	--accent-dark: #3730a3;
-	--accent-overlay: hsla(245, 70%, 60%, 0.15);
-	--accent-subtle-overlay: hsla(245, 50%, 96%, 1);
-	--accent-text-over: var(--gray-999);
+	--accent-regular: var(--color-accent);
+	--accent-regular-rgb: 29, 78, 216;
+	--accent-light: #dbeafe;
+	--accent-dark: var(--color-accent-hover);
+	--accent-overlay: rgba(29, 78, 216, 0.12);
+	--accent-subtle-overlay: var(--color-accent-soft);
+	--accent-text-over: var(--color-surface);
 
-	/* Link colors */
-	--link-color: var(--accent-regular);
+	--link-color: var(--color-accent);
 
 	/* Shadows */
-	--shadow-sm: 0px 2px 4px rgba(10, 12, 16, 0.1);
-	--shadow-md: 0px 4px 8px rgba(10, 12, 16, 0.12), 0px 2px 4px rgba(10, 12, 16, 0.08);
-	--shadow-lg: 0px 8px 16px rgba(10, 12, 16, 0.12), 0px 4px 8px rgba(10, 12, 16, 0.08);
+	--shadow-sm: 0px 1px 2px rgba(17, 24, 39, 0.08);
+	--shadow-md: 0px 4px 12px rgba(17, 24, 39, 0.1);
+	--shadow-lg: 0px 12px 24px rgba(17, 24, 39, 0.12);
 
 	/* Typography */
 	--text-sm: 0.875rem;
@@ -50,8 +63,10 @@
 	--text-5xl: 4.5rem;
 
 	/* Fonts */
-	--font-body: 'Source Sans 3', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-	--font-brand: 'Source Sans 3', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+	--font-body:
+		'Source Sans 3', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+	--font-brand:
+		'Source Sans 3', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 
 	/* Transition global */
 	--theme-transition: 0.2s ease-in-out;
@@ -68,9 +83,6 @@ body {
 
 body {
 	background-color: var(--gray-900);
-	background-image:
-		radial-gradient(circle at top left, rgba(79, 70, 229, 0.12), transparent 45%),
-		radial-gradient(circle at 20% 20%, rgba(129, 140, 248, 0.12), transparent 50%);
 	color: var(--gray-300);
 	font-family: var(--font-body);
 	-webkit-font-smoothing: antialiased;
@@ -135,7 +147,7 @@ aside {
 	overflow: visible;
 	clip: auto;
 	white-space: normal;
-	background: #fff;
+	background: var(--color-surface);
 	color: var(--accent-regular);
 	z-index: 1000;
 	padding: 0.5rem 1rem;
@@ -293,7 +305,7 @@ aside {
 		box-shadow 0.2s,
 		transform 0.2s;
 	appearance: none;
-	box-shadow: 0 12px 24px rgba(79, 70, 229, 0.25);
+	box-shadow: var(--shadow-md);
 }
 
 .cta:hover,
@@ -301,7 +313,7 @@ aside {
 	background-color: var(--accent-dark);
 	text-decoration: none;
 	transform: translateY(-2px);
-	box-shadow: 0 18px 30px rgba(79, 70, 229, 0.35);
+	box-shadow: var(--shadow-lg);
 }
 
 .cta:disabled,
@@ -363,10 +375,10 @@ aside {
 	flex-direction: column;
 	gap: 0.75rem;
 	padding: 1.25rem;
-	border: 1px solid rgba(203, 213, 225, 0.1);
+	border: 1px solid var(--gray-700);
 	border-radius: 1rem;
-	background: linear-gradient(180deg, rgba(248, 250, 252, 0.03), rgba(15, 23, 42, 0.2));
-	box-shadow: 0 12px 30px rgba(15, 23, 42, 0.2);
+	background: var(--gray-999);
+	box-shadow: var(--shadow-sm);
 	overflow: hidden;
 	position: relative;
 	transition:
@@ -377,8 +389,8 @@ aside {
 
 .portfolio-card:hover {
 	transform: translateY(-4px);
-	box-shadow: 0 20px 45px rgba(15, 23, 42, 0.28);
-	border-color: rgba(129, 140, 248, 0.45);
+	box-shadow: var(--shadow-md);
+	border-color: var(--accent-regular);
 }
 
 .portfolio-card:hover h2,
@@ -387,7 +399,7 @@ aside {
 }
 
 .portfolio-card:focus-within {
-	outline: 2px solid rgba(129, 140, 248, 0.6);
+	outline: 2px solid var(--accent-regular);
 	outline-offset: 3px;
 }
 
@@ -597,7 +609,7 @@ textarea {
 	width: 100%;
 	padding: 0.625em;
 	margin-bottom: 0.625em;
-	border: 3px solid #ccc;
+	border: 3px solid var(--color-border-strong);
 	border-radius: 3px;
 	box-sizing: border-box;
 	transition:
@@ -664,12 +676,12 @@ button[type='submit']:disabled {
 }
 
 .text-green-500 {
-	color: #10b981;
+	color: var(--color-success);
 	font-weight: 500;
 }
 
 .text-red-500 {
-	color: #ef4444;
+	color: var(--color-danger);
 	font-weight: 500;
 }
 
@@ -682,20 +694,20 @@ button[type='submit']:disabled {
 
 .was-validated input:invalid,
 .was-validated textarea:invalid {
-	border-color: #dc3545;
-	box-shadow: 0 0 0 3px rgba(220, 53, 69, 0.1);
+	border-color: var(--color-danger);
+	box-shadow: 0 0 0 3px rgba(185, 28, 28, 0.12);
 }
 
 .was-validated input:valid,
 .was-validated textarea:valid {
-	border-color: #28a745;
+	border-color: var(--color-success);
 }
 
 .invalid-feedback,
 .empty-feedback {
 	display: none;
 	font-size: var(--text-sm);
-	color: #dc3545;
+	color: var(--color-danger);
 	margin-bottom: 1.5rem;
 }
 
@@ -709,7 +721,7 @@ button[type='submit']:disabled {
 
 .is-invalid,
 .was-validated :invalid {
-	border-color: #dc3545;
+	border-color: var(--color-danger);
 }
 
 .form-container {
@@ -720,9 +732,9 @@ button[type='submit']:disabled {
 }
 
 form.needs-validation {
-	background: rgba(248, 250, 252, 0.9);
-	border: 1px solid rgba(15, 23, 42, 0.08);
-	box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
+	background: var(--gray-999);
+	border: 1px solid var(--gray-700);
+	box-shadow: var(--shadow-md);
 	border-radius: 1.25rem;
 	padding: 2rem;
 }
@@ -867,5 +879,5 @@ button::after {
 
 button.back-link:hover::after,
 button:hover::after {
-	background-color: hsla(var(--gray-999-basis), 0.3);
+	background-color: rgba(255, 255, 255, 0.3);
 }


### PR DESCRIPTION
## Summary
- Replace the layered gray/purple palette with a smaller semantic light palette
- Remove gradient backgrounds and reduce colored shadows in favor of neutral surfaces, borders, and shadows
- Align standalone sample pages with the same accessible colors

## Verification
- npm run lint
- npm run build
- npx prettier --check src/styles/global.css src/pages/samples/how-to.html src/pages/samples/user-guide.html
- Contrast spot-checks: body text 7.24:1, links 6.41:1, button text 6.70:1, danger 6.47:1, success 5.48:1
- Local preview smoke check on /, /portfolio/, /samples/how-to/, and /samples/user-guide/ with no console errors