### PR TITLE
fix: remove newline characters from taglines

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -15,7 +15,7 @@ import profilePicture from '../assets/profile-picture.jpg';
 			<header class="hero">
 				<Hero
 					title="Hello, I'm Arnaud Hervy"
-					tagline="I'm a technical writer working on developer-facing products: APIs, CLI tools, SDKs, and platforms.\nI work best where developers struggle to understand how something actually works, and where documentation needs to turn that into a usable path."
+					tagline="I'm a technical writer working on developer-facing products: APIs, CLI tools, SDKs, and platforms. I work best where developers struggle to understand how something actually works, and where documentation needs to turn that into a usable path."
 					align="start"
 				/>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -22,7 +22,7 @@ const projects = await getCollection('portfolio');
 			<header class="hero">
 				<Hero
 					title="Technical writer for API and developer platform teams"
-					tagline="I turn unclear developer workflows into documentation developers can ship from:\nAPI references, quickstarts, authentication guides, and migration docs."
+					tagline="I turn unclear developer workflows into documentation developers can ship from: API references, quickstarts, authentication guides, and migration docs."
 					align="start"
 				>
 					<div class="hero-buttons">


### PR DESCRIPTION
This pull request makes minor text formatting improvements to the tagline fields in two pages. The changes remove unnecessary newline characters from the taglines to ensure they display as a single, continuous sentence.

Text formatting improvements:

* [`src/pages/about.astro`](diffhunk://#diff-cb33463363c150558e340277672bb5c583640ddb38012f53a33ed69125d92038L18-R18): Removed a newline character from the `tagline` prop in the `Hero` component to keep the tagline on a single line.
* [`src/pages/index.astro`](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663L25-R25): Removed a newline character from the `tagline` prop in the `Hero` component to keep the tagline on a single line.