### PR TITLE
chore(deps): apply npm audit fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3198,16 +3198,16 @@
 			"license": "ISC"
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+			"integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
 			},
 			"engines": {
-				"node": "18 || 20 || >=22"
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/ccount": {
@@ -4936,9 +4936,9 @@
 			"license": "MIT"
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.17",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-			"integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+			"version": "3.3.18",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+			"integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
 			"funding": [
 				{
 					"type": "github",


### PR DESCRIPTION
## Summary
- update transitive `brace-expansion` from 5.0.7 to 5.0.9
- update transitive `nanoid` from 3.3.17 to 3.3.18
- leave direct dependency ranges unchanged

## Validation
- `npm audit --audit-level=low` (0 vulnerabilities)
- `npm run build`
- `npm run lint`
- `npm run format:check`
- `npm install --package-lock-only --ignore-scripts`
- `git diff --check`